### PR TITLE
Fix missing imports and constants in inline bot script

### DIFF
--- a/inline_bot.py
+++ b/inline_bot.py
@@ -8,12 +8,14 @@ import sys
 import platform
 import json
 import random
+import base64
 
 # for close tab.
 from selenium.common.exceptions import NoSuchWindowException
 from selenium.common.exceptions import UnexpectedAlertPresentException
 from selenium.common.exceptions import NoAlertPresentException
 from selenium.common.exceptions import WebDriverException
+from selenium import webdriver
 # for alert 2
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -46,6 +48,7 @@ CONST_MAXBOT_LAST_URL_FILE = "MAXBOT_LAST_URL.txt"
 CONST_MAXBOT_INT28_FILE = "MAXBOT_INT28_IDLE.txt"
 
 CONST_HOMEPAGE_DEFAULT = "https://inline.app/zh/?language=zh-tw"
+URL_CHROME_DRIVER = "https://chromedriver.chromium.org/downloads"
 
 CONST_CHROME_VERSION_NOT_MATCH_EN="Please download the WebDriver version to match your browser version."
 CONST_CHROME_VERSION_NOT_MATCH_TW="請下載與您瀏覽器相同版本的WebDriver版本，或更新您的瀏覽器版本。"


### PR DESCRIPTION
## Summary
- import the webdriver module and base64 helper used throughout the bot
- define the ChromeDriver download URL constant referenced in error messaging

## Testing
- python -m py_compile inline_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d4e9d866508324afc8e5cb218e50a5